### PR TITLE
Add vsock server/client example for Rust-C lib interaction

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
 
 [alias]
 mbuild = "build --target x86_64-unknown-uefi -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem"
+elfbuild = "xbuild --target rust-vsock-payload/target.json"

--- a/rust-vsock-payload/Cargo.toml
+++ b/rust-vsock-payload/Cargo.toml
@@ -11,6 +11,7 @@ atomic_refcell = "0.1.7"
 log = "0.4.13"
 linked_list_allocator = "0.8.11"
 conquer-once = { version = "0.3.2", default-features = false }
+spin = "0.7"
 
 rust-ipl-log = { path = "../rust-ipl-log" }
 r-uefi-pi = { path = "../r-uefi-pi" }
@@ -19,3 +20,7 @@ fw-pci = { path = "../fw-pci" }
 fw-exception = { path = "../fw-exception" }
 fw-virtio = { path = "../fw-virtio" }
 fw-vsock = { path = "../fw-vsock" }
+
+[dependencies.lazy_static]
+version = "1.0"
+features = ["spin_no_std"]

--- a/rust-vsock-payload/build.rs
+++ b/rust-vsock-payload/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+ 
+fn main() {
+    let out_dir = env::var("RUST_LINK_C_LIB_DIR").unwrap();
+    let lib_name = env::var("RUST_LINK_C_LIB_NAME").unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static={}", lib_name);
+}

--- a/rust-vsock-payload/readme.md
+++ b/rust-vsock-payload/readme.md
@@ -12,6 +12,12 @@ export RUST_IPL_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/rust_ipl.efi
 export RUST_PAYLOAD_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/rust-vsock-payload.efi
 export RUST_FIRMWARE_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/final_vsock.bin
 ```
+To link a static C library, set the folder and name of lib to the environment variable:
+
+```bash
+export RUST_LINK_C_LIB_DIR=$BASE_DIR/rust-vsock-payload/
+export RUST_LINK_C_LIB_NAME=main.a
+```
 
 To build default PE format OBJ and link with a static C library:
 

--- a/rust-vsock-payload/readme.md
+++ b/rust-vsock-payload/readme.md
@@ -11,11 +11,26 @@ export RESET_VECTOR_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/ResetVector
 export RUST_IPL_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/rust_ipl.efi
 export RUST_PAYLOAD_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/rust-vsock-payload.efi
 export RUST_FIRMWARE_BIN=$BASE_DIR/target/x86_64-unknown-uefi/release/final_vsock.bin
-
-cargo mbuild -p rust-vsock-payload --release
-cargo run -p rust-firmware-tool -- $RESET_VECTOR_BIN $RUST_IPL_BIN $RUST_PAYLOAD_BIN $RUST_FIRMWARE_BIN
-
 ```
+
+To build default PE format OBJ and link with a static C library:
+
+```bash
+cargo mbuild -p rust-vsock-payload --release
+```
+
+To build ELF format OBJ and link with a static C library:
+
+```bash
+cargo elfbuild -p rust-vsock-payload --release
+```
+
+Then:
+
+```bash
+cargo run -p rust-firmware-tool -- $RESET_VECTOR_BIN $RUST_IPL_BIN $RUST_PAYLOAD_BIN $RUST_FIRMWARE_BIN
+```
+
 
 ## How to Run
 

--- a/rust-vsock-payload/src/vsock_lib.rs
+++ b/rust-vsock-payload/src/vsock_lib.rs
@@ -1,0 +1,237 @@
+use core::slice;
+
+use fw_vsock::vsock::{VsockAddr, VsockStream};
+use alloc::collections::btree_map::BTreeMap;
+
+use lazy_static::lazy_static;
+use spin::Mutex;
+
+lazy_static! {
+    static ref SOCKET_COUNT: Mutex<i32> = Mutex::new(2);
+    static ref SOCKET_COLLECT: Mutex<BTreeMap<i32, Socket>> = Mutex::new(BTreeMap::new());
+}
+
+#[no_mangle]
+pub extern "C" fn socket_client () {
+    let mut s = VsockStream::new();
+    s.connect(&VsockAddr::new(2, 1234)).expect("error");
+    let _nsend = s.send(b"hello", 0).unwrap();
+}
+
+#[no_mangle]
+//to do: 1. object format (clang --target=x86_64-unknown-windows) 2. calling convention, substitute extern "C"
+pub extern "C" fn socket_server () {
+    let mut server_socket = VsockStream::new();
+    let listen_addrss = VsockAddr::new(33, 1234);
+    server_socket.bind(&listen_addrss).expect("bind error\n");
+    log::info!("listen on: {}\n", listen_addrss);
+    server_socket.listen(1).expect("listen error\n");
+    // can accept
+    let (mut client_socket, client_addr) = server_socket.accept().expect("accept failed\n");
+    log::info!("client accept: {}\n", client_addr);
+
+    loop {
+        let mut recv_buf = [0u8; 1024];
+        let recvn = client_socket
+            .recv(&mut recv_buf[..], 0)
+            .expect("recv error\n");
+        if recvn == 0 {
+            break;
+        }
+        log::info!("recv: {:?}\n", &recv_buf[..recvn]);
+    }
+}
+
+pub struct Socket {
+    vsock_stream: VsockStream,
+    remote: Option<VsockStream>
+}
+
+#[repr(C)]
+pub struct SockAddr {
+    svm_family: u16,
+    svm_reserved: u16,
+    svm_port: u32,
+    svm_cid: u32,
+    sa_data:[u8;4],
+}
+
+#[no_mangle]
+pub extern "C" fn socket (_domain: i32, _socket_type: i32, _protocol: i32) -> i32 {
+    let socket_stream = VsockStream::new();
+    *SOCKET_COUNT.lock() += 1;
+    let sockfd = *SOCKET_COUNT.lock();
+    let socket = Socket {vsock_stream: socket_stream, remote: None};
+    SOCKET_COLLECT.lock().insert(sockfd, socket);
+    sockfd
+}
+
+#[no_mangle]
+pub extern "C" fn bind (sockfd: i32, socket_addr: *mut SockAddr, _addrlen: u32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            unsafe {
+                log::info! ("bind sockaddr: cid: {}, port: {}\n", (*socket_addr).svm_cid, (*socket_addr).svm_port);
+                let listen_addrss = VsockAddr::new((*socket_addr).svm_cid, (*socket_addr).svm_port);
+                match socket.vsock_stream.bind(&listen_addrss) {
+                    Ok(()) => 0,
+                    Err(_e) => {
+                        log::info!("bind error\n");
+                        -1
+                    }
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn listen (sockfd: i32, backlog: i32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            match socket.vsock_stream.listen(backlog as u32) {
+                Ok(()) => 0,
+                Err(_e) => {
+                    log::info!("listen error\n");
+                    -1
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn accept (sockfd: i32, socket_addr: *mut SockAddr, addrlen: *mut u32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            match socket.vsock_stream.accept() {
+                Ok((remote, vsockaddr)) => {
+                    socket.remote = Some(remote);
+                    unsafe {
+                        (*socket_addr).svm_cid = vsockaddr.cid();
+                        (*socket_addr).svm_port = vsockaddr.port();
+                        *addrlen = 14;
+                    };
+                    0
+                },
+                Err(_e) => {
+                    log::info!("accept error\n");
+                    -1
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn connect (sockfd: i32, socket_addr: *mut SockAddr, _addrlen: u32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            // if socket.connected.
+            unsafe {
+                match socket.vsock_stream.connect(&VsockAddr::new((*socket_addr).svm_cid, (*socket_addr).svm_port)) {
+                    Ok(()) => 0,
+                    Err(_e) => {
+                        log::info!("connect error\n");
+                        -1
+                    }
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn recv (sockfd: i32, buf: *mut u8,  len: i32, flags: i32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            match &mut socket.remote {
+                Some(remote) => {
+                    unsafe {
+                        let recv_buf = slice::from_raw_parts_mut(buf, len as usize);
+                        let recvn = remote
+                            .recv(&mut recv_buf[..], flags as u32)
+                            .expect("recv error\n");
+                        if recvn == 0 {
+                            // socket.remote = None;
+                            return 0;
+                        }
+                        log::info!("recv: {:?}\n", &recv_buf[..recvn]);
+                        recvn as i32
+                    }
+                }
+                None => {
+                    log::info!("client not found\n");
+                    return -1
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn shutdown (sockfd: i32, _how: i32) -> i32 {
+    let mut tree = SOCKET_COLLECT.lock();
+    match tree.get_mut(&sockfd) {
+        Some(socket) => {
+            match socket.vsock_stream.shutdown() {
+                Ok(()) => {
+                    tree.remove(&sockfd).expect("remove socketfd error\n");
+                    0
+                },
+                Err(_e) => {
+                    log::info!("shutdown error\n");
+                    0
+                }
+            }
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn send (sockfd: i32, buf: *mut u8,  len: i32, flags: i32) -> i32 {
+    match SOCKET_COLLECT.lock().get_mut(&sockfd) {
+        Some(socket) => {
+            unsafe {
+                let send_buf = slice::from_raw_parts(buf, len as usize);
+                log::info!("send len: {:}\n", len);
+                let sendn = socket.vsock_stream
+                    .send(&send_buf[..], flags as u32)
+                    .expect("send error\n");
+                if sendn == 0 {
+                    return -1;
+                }
+                log::info!("send: {:?}\n", &send_buf[..len as usize]);
+            }
+            0
+        },
+        None => {
+            log::info!("sockfd: {} not found\n", sockfd);
+            -1
+        },
+    }
+}

--- a/rust-vsock-payload/target.json
+++ b/rust-vsock-payload/target.json
@@ -1,0 +1,16 @@
+{
+  "llvm-target": "x86_64-unknown-none",
+  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "arch": "x86_64",
+  "target-endian": "little",
+  "target-pointer-width": "64",
+  "target-c-int-width": "32",
+  "os": "none",
+  "executables": true,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "panic-strategy": "abort",
+  "disable-redzone": true,
+  "features": "-mmx,-sse,+soft-float",
+  "position-independent-executables": true
+}

--- a/rust-vsock-payload/vsock_c_lib/main.c
+++ b/rust-vsock-payload/vsock_c_lib/main.c
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// This example does the same work as rust-vsock-payload/src/server.rs
+//
+
+#include <sys/types.h>
+
+typedef unsigned int socklen_t;
+
+struct sockaddr {
+	unsigned short svm_family;
+	unsigned short svm_reserved1;
+	unsigned int   svm_port;
+	unsigned int   svm_cid;
+	unsigned char  svm_flags;
+	unsigned char  svm_zero[3];
+};
+
+extern int     socket (int family, int type, int protocol);
+extern int     bind (int sockfd, const struct sockaddr *addr,socklen_t addrlen);
+extern int     listen (int sockfd, int backlog);
+extern int     accept (int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+extern ssize_t recv (int sockfd, void *buf, size_t len, int flags);
+extern int     connect (int sockfd, const struct sockaddr *addr,socklen_t addrlen);
+extern ssize_t send (int sockfd, void *buf, size_t len, int flags);
+extern int     shutdown (int fd, int how);
+
+#define RECV_BUF_LEN 1024
+
+int server_entry () {
+  int             sockfd;
+  unsigned char   buf[1024];
+  struct sockaddr bindAddr;
+  socklen_t       bindAddrLen;
+  struct sockaddr acceptAddr;
+  socklen_t       acceptAddrLen;
+
+  bindAddr.svm_port = 1234;
+  bindAddr.svm_cid  = 33;
+  bindAddrLen       = 11;
+
+  sockfd = socket (0, 0, 0);
+
+  if (bind (sockfd, &bindAddr, bindAddrLen)) {
+    return -1;
+  }
+
+  if (listen (sockfd, 1)) {
+    return -1;
+  }
+
+  if (accept (sockfd, &acceptAddr, &acceptAddrLen)) {
+    return -1;
+  }
+
+  while (1) {
+    if (!recv (sockfd, buf, 1024, 0)) {
+      break;
+    }
+  }
+
+  if (shutdown (sockfd, 0)) {
+    return -1;
+  }
+  return 0;
+}
+
+
+
+int client_entry () {
+  int             sockfd;
+  struct sockaddr serverAddr;
+  socklen_t       serverAddrLen;
+
+  sockfd = socket (0, 0, 0);
+
+  serverAddr.svm_port = 1234;
+  serverAddr.svm_cid  = 2;
+  serverAddrLen       = 11;
+
+  if (connect (sockfd, &serverAddr, serverAddrLen)) {
+      return -1;
+  }
+
+  if (send (sockfd, "hello", 5, 0)) {
+    return -1;
+  }
+
+  if (shutdown (sockfd, 0)) {
+    return -1;
+  }
+  return 0;
+}


### PR DESCRIPTION
1. Build vsock payload as ELF format and GCC calling convention.
2. Add an example for Rust-C lib interaction.